### PR TITLE
Refactor AMA_Geotab_Terminales: migrar a geotab_planned_vs_actual

### DIFF
--- a/models/ama/AMA_Geotab_Terminales.sql
+++ b/models/ama/AMA_Geotab_Terminales.sql
@@ -10,233 +10,164 @@
     {% else %} SELECT 1 AS noop {% endif %}"
 ) }}
 
-WITH pos AS (
+/*
+  Fuente principal: staging.geotab_planned_vs_actual
+  - Cada fila = una parada planificada en una ruta para un vehículo.
+  - status = 'ON_TIME' → el vehículo visitó físicamente la zona (tiene actual_arrival/departure).
+  - La tabla se actualiza en múltiples snapshots diarios; se deduplica por
+    (device_id, route_id, stop_sequence, actual_arrival_utc) usando _md_filename DESC.
+  - Solo se incluyen filas ON_TIME (visitas reales al terminal).
+*/
+
+WITH cte_deduped AS (
+    -- Eliminar duplicados por snapshot: conservar una fila por visita única
     SELECT
-        zone_id,
-        zone_name,
-        zone_types_json,
-        external_reference,
-        must_identify_stops,
-        active_from,
-        active_to,
-        -- posición del token "id" dentro del JSON
-        CHARINDEX('"id"', zone_types_json)          AS id_key_pos
-    FROM {{ source('geotab', 'geotab_zone') }}
-),
-
-val_pos AS (
-    SELECT
-        *,
-        -- posición del primer " que abre el valor del id (sólo relevante si id_key_pos > 0)
-        CASE
-            WHEN id_key_pos > 0
-            THEN CHARINDEX('"', zone_types_json,
-                     CHARINDEX(':', zone_types_json, id_key_pos + 4) + 1)
-            ELSE 0
-        END                                         AS val_start_pos
-    FROM pos
-),
-
-stg_geotab__zone AS (
-SELECT
-    z.zone_id,
-    z.zone_name,
-    z.external_reference,
-    z.must_identify_stops,
-    z.active_from,
-    z.active_to,
-
-    -- Referencia al tipo: ID custom o nombre built-in
-    CASE
-        WHEN z.id_key_pos > 0
-            -- Custom: [{"id": "b22"}] → extraer valor entre las comillas del id
-            THEN SUBSTRING(
-                z.zone_types_json,
-                z.val_start_pos + 1,
-                CHARINDEX('"', z.zone_types_json, z.val_start_pos + 1) - z.val_start_pos - 1
-            )
-        ELSE
-            -- Built-in: ["ZoneTypeCustomerId"] → extraer el nombre entre [" y "]
-            SUBSTRING(z.zone_types_json, 3, LEN(z.zone_types_json) - 4)
-    END                                             AS zone_type_ref,
-
-    CAST(
-        CASE WHEN z.id_key_pos > 0 THEN 1 ELSE 0 END
-    AS BIT)                                         AS is_custom_type,
-
-    -- Nombre del tipo resuelto (solo para tipos custom con registro en geotab_zone_type)
-    zt.zone_type_name
-
-FROM val_pos z
-LEFT JOIN {{ source('geotab', 'geotab_zone_type') }} zt
-    ON zt.zone_type_id = CASE
-        WHEN z.id_key_pos > 0
-        THEN SUBSTRING(
-            z.zone_types_json,
-            z.val_start_pos + 1,
-            CHARINDEX('"', z.zone_types_json, z.val_start_pos + 1) - z.val_start_pos - 1
-        )
-        ELSE NULL
-    END),
-
-
-cte_zonas AS (
-    SELECT
-        z.zone_id,
-        z.zone_name,
-        z.zone_type_name                AS zone_type,
-        z.external_reference            AS terminal_codigo_externo,
-        z.active_from                   AS zona_activa_desde,
-        z.active_to                     AS zona_activa_hasta
-    FROM stg_geotab__zone z
-    WHERE (z.active_to IS NULL OR z.active_to > GETDATE())
-      -- AND z.zone_type_name = 'Terminal'
-),
-
-cte_zona_ruta AS (
-    -- Resuelve zone_id → route vía route_plan_item.
-    -- ROW_NUMBER deduplica en caso de que una zona pertenezca a múltiples rutas.
-    SELECT
-        rpi.zone_id,
-        r.route_id,
-        r.name as route_name,
-        ROW_NUMBER() OVER (PARTITION BY rpi.zone_id ORDER BY r.route_id) AS rn
-    FROM {{ source('geotab', 'geotab_route_plan_item') }} rpi
-    INNER JOIN {{ source('geotab', 'geotab_route') }} r ON r.route_id = rpi.route_id
-),
-
-cte_rules AS (
-    SELECT
-        r.rule_id,
-        r.name as rule_name,
-        z.zone_id,
-        z.zone_name,
-        z.zone_type,
-        z.terminal_codigo_externo,
-        zr.route_id,
-        zr.route_name
-    FROM {{ source('geotab', 'geotab_rule') }} r
-    LEFT JOIN cte_zonas z
-        ON z.zone_name = r.name
-    LEFT JOIN cte_zona_ruta zr
-        ON zr.zone_id = z.zone_id AND zr.rn = 1
-    -- Filtrar solo reglas de tipo ZoneStop
-    -- WHERE r.base_type = 'ZoneStop'
-),
-
-
-cte_eventos AS (
-    SELECT
-        ee.exception_event_id,
-        ee.device_id,
-        ee.driver_id,
-        ee.rule_id,                                 -- puente hacia la zona
-        cr.zone_id,                                 -- ← resuelto via Rule
-        cr.zone_name,
-        cr.zone_type,
-        cr.terminal_codigo_externo,
-        cr.route_id,
-        cr.route_name,
-        CONVERT(DATETIME, ee.active_from)           AS active_from,
-        CONVERT(DATETIME, ee.active_to)             AS active_to,
-        CASE
-            WHEN ee.active_from IS NOT NULL
-             AND ee.active_to   IS NOT NULL
-            THEN CAST(
-                DATEDIFF(SECOND, ee.active_from, ee.active_to) / 60.0
-                AS DECIMAL(10, 2))
-            ELSE NULL
-        END                                         AS dwell_time_minutes,
-        CONVERT(DATE,     ee.active_from)           AS event_date,
-        DATEPART(HOUR,    ee.active_from)           AS entry_hour,
-        DATEPART(WEEKDAY, ee.active_from)           AS entry_weekday
-    FROM {{ source('geotab', 'geotab_exception_event') }} ee
-    -- Join hacia la zona via Rule
-    INNER JOIN cte_rules cr
-        ON cr.rule_id = ee.rule_id
+        route_id,
+        route_name,
+        device_id,
+        device_name,
+        stop_sequence,
+        stop_name,
+        arrival_zone_id,
+        arrival_zone_name,
+        CAST(actual_arrival_utc   AS DATETIME)    AS actual_arrival_utc,
+        CAST(actual_departure_utc AS DATETIME)    AS actual_departure_utc,
+        status,
+        CAST(ISNULL(variance_minutes, 0) AS DECIMAL(10, 2)) AS variance_minutes,
+        note,
+        ROW_NUMBER() OVER (
+            PARTITION BY device_id, route_id, stop_sequence, actual_arrival_utc
+            ORDER BY _md_filename DESC
+        ) AS rn
+    FROM {{ source('geotab', 'geotab_planned_vs_actual') }}
+    WHERE status = 'ON_TIME'
     {% if is_incremental() %}
-    WHERE ee.active_from >= DATEADD(DAY, -1, CAST(GETDATE() AS DATE))
+      AND CAST(actual_arrival_utc AS DATE) >= DATEADD(DAY, -1, CAST(GETDATE() AS DATE))
     {% endif %}
 ),
 
-cte_viaje_siguiente AS (
+cte_visits AS (
+    SELECT *
+    FROM cte_deduped
+    WHERE rn = 1
+),
+
+cte_device AS (
+    SELECT device_id, device_type
+    FROM {{ source('geotab', 'geotab_device') }}
+),
+
+-- Siguiente viaje del vehículo dentro de las 4 horas posteriores a la salida del terminal
+cte_next_trip AS (
     SELECT
-        ev.exception_event_id,
-        MIN(t.trip_start)   AS next_trip_start,
-        MIN(t.trip_id)      AS next_trip_id
-    FROM cte_eventos ev
+        v.device_id,
+        v.route_id,
+        v.stop_sequence,
+        v.actual_arrival_utc,
+        MIN(t.trip_start) AS next_trip_start,
+        MIN(t.trip_id)    AS next_trip_id
+    FROM cte_visits v
     JOIN {{ source('geotab', 'geotab_trip') }} t
-        ON  t.device_id  = ev.device_id
-        AND t.trip_start >= ev.active_to
-        AND t.trip_start <  DATEADD(HOUR, 4, ev.active_to)
-    WHERE ev.active_to IS NOT NULL
-    GROUP BY ev.exception_event_id
+        ON  t.device_id  = v.device_id
+        AND t.trip_start >= v.actual_departure_utc
+        AND t.trip_start <  DATEADD(HOUR, 4, v.actual_departure_utc)
+    WHERE v.actual_departure_utc IS NOT NULL
+    GROUP BY v.device_id, v.route_id, v.stop_sequence, v.actual_arrival_utc
 )
 
 SELECT
-    -- Identificadores
-    ev.exception_event_id,
-    ev.event_date,
-    ev.entry_hour,
-    ev.entry_weekday,
+    -- Evento
+    CAST(v.actual_arrival_utc AS DATE)                      AS event_date,
+    DATEPART(HOUR,    v.actual_arrival_utc)                 AS entry_hour,
+    DATEPART(WEEKDAY, v.actual_arrival_utc)                 AS entry_weekday,
 
-    -- Terminal (zone_id ahora resuelto via Rule)
-    ev.zone_id,
-    ev.zone_name                                            AS terminal_name,
-    ev.zone_type                                            AS terminal_type,
-    ev.terminal_codigo_externo,
+    -- Zona / Terminal (resueltos directamente desde planned_vs_actual)
+    v.arrival_zone_id                                       AS zone_id,
+    v.arrival_zone_name                                     AS terminal_name,
+
+    -- Indicador de terminal central (Estacion Martinez Nadal)
+    CAST(
+        CASE
+            WHEN v.arrival_zone_name = 'Estacion Martinez Nadal (Abordaje/Descenso), San Juan, 00921, Puerto Rico'
+            THEN 1 ELSE 0
+        END
+    AS BIT)                                                 AS is_central,
 
     -- Vehículo
-    ev.device_id                                            AS vehicle_id,
-    d.device_name                                           AS vehicle_name,
+    v.device_id                                             AS vehicle_id,
+    v.device_name                                           AS vehicle_name,
     d.device_type                                           AS vehicle_type,
 
-    -- Conductor
-    ev.driver_id,
+    -- Ruta (resuelta directamente desde planned_vs_actual)
+    v.route_id,
+    v.route_name,
+
+    -- Parada en la ruta
+    v.stop_sequence,
+    v.stop_name,
 
     -- Tiempos del evento en terminal
-    ev.active_from                                          AS terminal_entry_datetime,
-    ev.active_to                                            AS terminal_exit_datetime,
-    ev.dwell_time_minutes,
+    v.actual_arrival_utc                                    AS terminal_entry_datetime,
+    v.actual_departure_utc                                  AS terminal_exit_datetime,
+    CASE
+        WHEN v.actual_arrival_utc IS NOT NULL
+         AND v.actual_departure_utc IS NOT NULL
+        THEN CAST(
+            DATEDIFF(SECOND, v.actual_arrival_utc, v.actual_departure_utc) / 60.0
+            AS DECIMAL(10, 2))
+        ELSE NULL
+    END                                                     AS dwell_time_minutes,
 
     -- Clasificación de permanencia
     CASE
-        WHEN ev.dwell_time_minutes IS NULL              THEN 'SIN_DATOS'
-        WHEN ev.dwell_time_minutes < 5                  THEN 'RAPIDO'
-        WHEN ev.dwell_time_minutes BETWEEN 5  AND 15    THEN 'NORMAL'
-        WHEN ev.dwell_time_minutes BETWEEN 15 AND 30    THEN 'DEMORADO'
-        ELSE                                                 'CUELLO_DE_BOTELLA'
+        WHEN v.actual_departure_utc IS NULL
+            THEN 'SIN_DATOS'
+        WHEN DATEDIFF(SECOND, v.actual_arrival_utc, v.actual_departure_utc) / 60.0 < 5
+            THEN 'RAPIDO'
+        WHEN DATEDIFF(SECOND, v.actual_arrival_utc, v.actual_departure_utc) / 60.0 BETWEEN 5  AND 15
+            THEN 'NORMAL'
+        WHEN DATEDIFF(SECOND, v.actual_arrival_utc, v.actual_departure_utc) / 60.0 BETWEEN 15 AND 30
+            THEN 'DEMORADO'
+        ELSE
+            'CUELLO_DE_BOTELLA'
     END                                                     AS dwell_categoria,
     CAST(
-        CASE WHEN ev.dwell_time_minutes > 30 THEN 1 ELSE 0 END
+        CASE
+            WHEN v.actual_departure_utc IS NOT NULL
+             AND DATEDIFF(SECOND, v.actual_arrival_utc, v.actual_departure_utc) / 60.0 > 30
+            THEN 1 ELSE 0
+        END
     AS BIT)                                                 AS es_cuello_de_botella,
 
     -- Franja horaria
     CASE
-        WHEN ev.entry_hour BETWEEN 5  AND 8  THEN 'MANANA_TEMPRANA'
-        WHEN ev.entry_hour BETWEEN 9  AND 11 THEN 'MANANA'
-        WHEN ev.entry_hour BETWEEN 12 AND 14 THEN 'MEDIODIA'
-        WHEN ev.entry_hour BETWEEN 15 AND 18 THEN 'TARDE'
-        WHEN ev.entry_hour BETWEEN 19 AND 22 THEN 'NOCHE'
-        ELSE                                     'MADRUGADA'
+        WHEN DATEPART(HOUR, v.actual_arrival_utc) BETWEEN 5  AND 8  THEN 'MANANA_TEMPRANA'
+        WHEN DATEPART(HOUR, v.actual_arrival_utc) BETWEEN 9  AND 11 THEN 'MANANA'
+        WHEN DATEPART(HOUR, v.actual_arrival_utc) BETWEEN 12 AND 14 THEN 'MEDIODIA'
+        WHEN DATEPART(HOUR, v.actual_arrival_utc) BETWEEN 15 AND 18 THEN 'TARDE'
+        WHEN DATEPART(HOUR, v.actual_arrival_utc) BETWEEN 19 AND 22 THEN 'NOCHE'
+        ELSE                                                              'MADRUGADA'
     END                                                     AS franja_horaria,
 
-    -- Viaje posterior
-    vs.next_trip_id,
-    vs.next_trip_start,
-    DATEDIFF(MINUTE, ev.active_to, vs.next_trip_start)     AS minutos_hasta_viaje,
+    -- Viaje posterior al evento en terminal
+    nt.next_trip_id,
+    nt.next_trip_start,
+    DATEDIFF(MINUTE, v.actual_departure_utc, nt.next_trip_start) AS minutos_hasta_viaje,
 
-    -- Ruta asociada al terminal (vía geotab_route_plan_item → geotab_route)
-    ev.route_id,
-    ev.route_name,
-
-    -- ITINERARIO: pendiente dataset AMA
+    -- Estado e itinerario (ahora poblados desde planned_vs_actual)
+    v.status                                                AS departure_status,
+    v.variance_minutes                                      AS delay_minutes,
+    -- Los tiempos planificados en esta fuente son valores centinela (1986/2050); se mantiene NULL
     CAST(NULL AS DATETIME)                                  AS scheduled_departure,
-    CAST(NULL AS INT)                                       AS delay_minutes,
-    CAST(NULL AS NVARCHAR(50))                              AS departure_status
 
-FROM cte_eventos ev
-LEFT JOIN {{ source('geotab', 'geotab_device') }} d
-    ON d.device_id = ev.device_id
-LEFT JOIN cte_viaje_siguiente vs
-    ON vs.exception_event_id = ev.exception_event_id
+    -- Nota del proveedor sobre el evento
+    v.note                                                  AS event_note
+
+FROM cte_visits v
+LEFT JOIN cte_device d
+    ON d.device_id = v.device_id
+LEFT JOIN cte_next_trip nt
+    ON  nt.device_id          = v.device_id
+    AND nt.route_id           = v.route_id
+    AND nt.stop_sequence      = v.stop_sequence
+    AND nt.actual_arrival_utc = v.actual_arrival_utc

--- a/models/sources/geotab.yml
+++ b/models/sources/geotab.yml
@@ -18,3 +18,4 @@ sources:
       - name: geotab_zone
       - name: geotab_zone_type
       - name: geotab_rule
+      - name: geotab_planned_vs_actual


### PR DESCRIPTION
Reemplaza la cadena de CTEs de resolución de zonas/rutas via exception_event
+ Rule + zone_types_json por la fuente geotab_planned_vs_actual donde la información de terminal, ruta y zona ya está resuelta por el proveedor.

- Elimina CTEs: pos, val_pos, stg_geotab__zone, cte_zonas, cte_zona_ruta, cte_rules, cte_eventos (origen de los NULLs en terminal y ruta)
- Deduplicación por snapshot: ROW_NUMBER OVER (PARTITION BY device_id, route_id, stop_sequence, actual_arrival_utc ORDER BY _md_filename DESC)
- Agrega columna is_central (BIT) para identificar viajes desde/hacia Estacion Martinez Nadal
- departure_status y delay_minutes ahora se pueblan con datos reales
- Registra geotab_planned_vs_actual en models/sources/geotab.yml