### PR TITLE
feat(tests): add dbt data quality tests across ATI, Sonnell and AMA d…

### DIFF
--- a/models/ati_datawarehouse/schema.yml
+++ b/models/ati_datawarehouse/schema.yml
@@ -1,0 +1,167 @@
+version: 2
+
+models:
+  - name: fleet
+    description: >
+      Tabla de flotas Korbato deduplicada. Grain: fleet_key único (una fila por flota,
+      fila más reciente por _md_processed_at via staging_fleet rn=1).
+    columns:
+      - name: fleet_key
+        description: "PK — identificador único de flota"
+        tests:
+          - unique
+          - not_null
+      - name: fleet_name
+        description: "Nombre de la flota"
+        tests:
+          - not_null
+      - name: operator_id
+        description: "Identificador del operador al que pertenece la flota"
+        tests:
+          - not_null
+      - name: _md_processed_at
+        description: "Timestamp de procesamiento del archivo fuente en el data lake"
+        tests:
+          - not_null
+
+  - name: vehicle_day
+    description: >
+      Tabla de vehículos por día de servicio. Grain: vehicle_day_key único
+      (una fila por combinación vehículo-día, rn=1 del staging).
+    columns:
+      - name: vehicle_day_key
+        description: "PK — clave única de vehículo por día"
+        tests:
+          - unique
+          - not_null
+      - name: svc_date
+        description: "Fecha de servicio"
+        tests:
+          - not_null
+      - name: fleet_key
+        description: "FK a fleet.fleet_key"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('fleet')
+              field: fleet_key
+      - name: vehicle_id
+        description: "Identificador del vehículo"
+        tests:
+          - not_null
+
+  - name: trip
+    description: >
+      Tabla de viajes Korbato deduplicada. Grain: trip_key único (rn=1 del staging).
+      Incremental: ventana del último día en svc_date.
+    columns:
+      - name: trip_key
+        description: "PK — clave única de viaje"
+        tests:
+          - unique
+          - not_null
+      - name: svc_date
+        description: "Fecha de servicio del viaje"
+        tests:
+          - not_null
+      - name: vehicle_day_key
+        description: "FK a vehicle_day.vehicle_day_key"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('vehicle_day')
+              field: vehicle_day_key
+      - name: route_id
+        description: "Identificador de ruta"
+        tests:
+          - not_null
+
+  - name: visit
+    description: >
+      Tabla de visitas a paradas por viaje. Grain: visit_key único (rn=1 del staging).
+      Incremental: ventana del último día en svc_date.
+    columns:
+      - name: visit_key
+        description: "PK — clave única de visita"
+        tests:
+          - unique
+          - not_null
+      - name: svc_date
+        description: "Fecha de servicio"
+        tests:
+          - not_null
+      - name: trip_key
+        description: "FK a trip.trip_key"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('trip')
+              field: trip_key
+      - name: stop_id
+        description: "Identificador de la parada visitada"
+        tests:
+          - not_null
+
+  - name: pattern
+    description: >
+      Tabla de patrones de rutas Korbato. Grain: pattern_id único
+      (una fila por patrón, rn=1 del staging).
+    columns:
+      - name: pattern_id
+        description: "PK — identificador único del patrón de ruta"
+        tests:
+          - unique
+          - not_null
+      - name: route_id
+        description: "Ruta a la que pertenece el patrón"
+        tests:
+          - not_null
+
+  - name: pattern_stop
+    description: >
+      Paradas que componen cada patrón de ruta. Grain: (pattern_id, stop_seq).
+      Una fila por parada dentro de cada patrón (rn=1 del staging).
+    columns:
+      - name: pattern_id
+        description: "PK compuesta: FK a pattern.pattern_id"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('pattern')
+              field: pattern_id
+      - name: stop_seq
+        description: "PK compuesta: posición ordinal de la parada dentro del patrón"
+        tests:
+          - not_null
+      - name: stop_id
+        description: "Identificador de la parada"
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pattern_id
+            - stop_seq
+
+  - name: Trip_Sch_Match
+    description: >
+      Matcheo de viajes reales (Korbato) contra trips programados (GTFS).
+      Grain: (svc_date, trip_key) — un registro de matcheo por viaje y día.
+      Incremental: ventana del último día en svc_date.
+    columns:
+      - name: svc_date
+        description: "PK compuesta: fecha de servicio"
+        tests:
+          - not_null
+      - name: trip_key
+        description: "PK compuesta: FK a trip.trip_key"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('trip')
+              field: trip_key
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - svc_date
+            - trip_key

--- a/models/sources/external.yml
+++ b/models/sources/external.yml
@@ -2,12 +2,38 @@ version: 2
 
 sources:
   - name: external
-    description: ""
+    description: "Tablas externas del data lake (Parquet) en schema raw. Leídas via PolyBase/external tables en Synapse."
     schema: raw
     tables:
-      - name: Sonnell_checkpoin
-      - name: sonnell_subsystem
+      # --- Sonnell (con freshness) ---
       - name: sonnell_trip
+        description: >
+          Viajes del pipeline Sonnell. Fuente de stg_sonnell_trip (alias SonnellTrips).
+          Cargado diariamente desde el data lake.
+        loaded_at_field: _md_processed_at
+        freshness:
+          warn_after:  {count: 2, period: day}
+          error_after: {count: 3, period: day}
+
+      - name: Sonnell_checkpoin
+        description: >
+          Checkpoints de OTP del pipeline Sonnell. Fuente de stg_sonnell_checkpoints (alias SonnellCheckpoints).
+          Cargado diariamente desde el data lake.
+        loaded_at_field: _md_processed_at
+        freshness:
+          warn_after:  {count: 2, period: day}
+          error_after: {count: 3, period: day}
+
+      - name: sonnell_subsystem
+        description: >
+          Resumen diario por subsistema del pipeline Sonnell. Fuente de stg_sonnell_daily_summary (alias SonnellDailySummary).
+          Cargado diariamente desde el data lake.
+        loaded_at_field: _md_processed_at
+        freshness:
+          warn_after:  {count: 2, period: day}
+          error_after: {count: 3, period: day}
+
+      # --- Korbato ATI (sin freshness configurada) ---
       - name: fleet
       - name: pattern
       - name: pattern_stop

--- a/tests/assert_ama_no_future_trips.sql
+++ b/tests/assert_ama_no_future_trips.sql
@@ -1,0 +1,12 @@
+-- Devuelve filas si algún viaje tiene actual_departure en el futuro.
+-- Un timestamp futuro indica corrupción en geotab_trip (zona horaria mal
+-- configurada en el dispositivo o error de ingesta).
+
+SELECT
+    trip_id,
+    vehicle_name,
+    actual_departure,
+    GETDATE()                                              AS current_datetime,
+    DATEDIFF(MINUTE, GETDATE(), actual_departure)          AS minutes_ahead
+FROM {{ ref('AMA_Geotab_Viajes') }}
+WHERE actual_departure > GETDATE()

--- a/tests/assert_sonnell_invoice_non_negative.sql
+++ b/tests/assert_sonnell_invoice_non_negative.sql
@@ -1,0 +1,15 @@
+-- Devuelve filas si alguna línea Regular de factura tiene Total negativo.
+-- Un Total < 0 en tipo 'Regular' indica error de cálculo — los créditos
+-- van exclusivamente por líneas de tipo 'Offset'.
+
+SELECT
+    [Year],
+    [Month],
+    Subsystem,
+    [Type],
+    Total,
+    Version
+FROM {{ ref('fct_sonnell_invoice_totals') }}
+WHERE CurrentVersion = CAST(1 AS BIT)
+  AND [Type] = 'Regular'
+  AND Total < 0

--- a/tests/assert_sonnell_offset_cap_4_percent.sql
+++ b/tests/assert_sonnell_offset_cap_4_percent.sql
@@ -1,0 +1,15 @@
+-- Devuelve filas cuando el offset de un subsistema supera el 4% del costo total.
+-- Según la regla de negocio, el cap del 4% es informacional: no bloquea la factura
+-- pero debe auditarse. Este test alerta cuando se supera el umbral.
+
+SELECT
+    [Year],
+    [Month],
+    Subsystem,
+    TotalSubsystemCost,
+    TotalOffset,
+    ROUND(ABS(TotalOffset) / NULLIF(TotalSubsystemCost, 0) * 100, 2) AS offset_pct
+FROM {{ ref('fct_sonnell_subsystem_offset') }}
+WHERE CurrentVersion = CAST(1 AS BIT)
+  AND TotalSubsystemCost > 0
+  AND ABS(TotalOffset) / NULLIF(TotalSubsystemCost, 0) > 0.04

--- a/tests/assert_sonnell_one_active_version_per_month.sql
+++ b/tests/assert_sonnell_one_active_version_per_month.sql
@@ -1,0 +1,13 @@
+-- Devuelve filas si un mismo (Year, Month) tiene más de una Version con
+-- CurrentVersion = 1 en fct_sonnell_invoice_totals.
+-- Más de una versión activa indica que el pre_hook de SCD Type 2 falló
+-- y no marcó la versión anterior como CurrentVersion = 0.
+
+SELECT
+    [Year],
+    [Month],
+    COUNT(DISTINCT Version) AS versiones_activas
+FROM {{ ref('fct_sonnell_invoice_totals') }}
+WHERE CurrentVersion = CAST(1 AS BIT)
+GROUP BY [Year], [Month]
+HAVING COUNT(DISTINCT Version) > 1


### PR DESCRIPTION
…omains

- Add schema.yml for ati_datawarehouse with PK/FK tests on fleet, trip, vehicle_day, visit, pattern, pattern_stop and Trip_Sch_Match
- Add singular tests: invoice non-negative, no future AMA trips, Sonnell offset cap 4%, and single active version per month
- Add freshness config (warn 2d / error 3d) on external Sonnell sources