### PR TITLE
fix(monitoring): include snapshots in SLA evaluation

### DIFF
--- a/models/monitoring/intermediate/int_health_metrics.sql
+++ b/models/monitoring/intermediate/int_health_metrics.sql
@@ -142,17 +142,14 @@ with_health AS (
             (30 - (is_volume_anomaly * 10) - (is_zero_records * 10) - (is_high_failure_rate * 10))
         AS DECIMAL(5, 2)) AS health_score,
 
-        -- SLA compliance (NULL for snapshots)
+        -- SLA compliance: aplica a recurring Y snapshot (snapshots korbato tienen SLA de 24h)
         CASE
-            WHEN entity_type = 'snapshot'                                THEN CAST(NULL AS BIT)
             WHEN last_success_datetime IS NULL                           THEN CAST(0 AS BIT)
             WHEN hours_since_success_eod <= expected_frequency_hrs       THEN CAST(1 AS BIT)
             ELSE CAST(0 AS BIT)
         END AS sla_met,
 
         CASE
-            WHEN entity_type = 'snapshot'
-                THEN 'N/A - snapshot file'
             WHEN last_success_datetime IS NULL
                 THEN 'No successful execution recorded'
             WHEN hours_since_success_eod > expected_frequency_hrs

--- a/models/monitoring/marts/_fct_monitoring__models.yml
+++ b/models/monitoring/marts/_fct_monitoring__models.yml
@@ -269,13 +269,13 @@ models:
       - name: sla_met
         description: >
           1 si hours_since_success <= expected_frequency_hrs.
-          NULL para archivos snapshot (no aplica SLA).
+          Aplica a recurring y snapshot (snapshots korbato tienen SLA de 24h).
+          0 si no hubo ejecucion exitosa o se supero el umbral.
         data_type: bit
         tests:
+          - not_null
           - accepted_values:
               values: [0, 1]
-              config:
-                where: "entity_type = 'recurring'"
       - name: sla_breach_reason
         description: Descripcion del incumplimiento de SLA (NULL si sla_met = 1)
         data_type: varchar(255)


### PR DESCRIPTION
sla_met was returning NULL for entity_type = 'snapshot' by design error. All snapshots come from source 'korbato' and must comply with the 24h SLA. Removed the snapshot exception so sla_met evaluates all entity types uniformly. Updated schema.yml to add not_null test and remove the recurring-only where clause.