### PR TITLE
fix(sonnell): add IsActive filter to subsystem_cost rate join

### DIFF
--- a/models/sonnell/README.md
+++ b/models/sonnell/README.md
@@ -278,6 +278,8 @@ All tables use `ROUND_ROBIN` distribution and `CLUSTERED COLUMNSTORE INDEX`.
 
 4. **MU route stats as no-ops**: SP2 attempts to update RevenueMiles/RevenueHours for MU routes, but the `GroupId = Subsystem` join fails ('MU' != 'MU - 20'). This is a known SP behavior that we replicate by omitting those UPDATEs.
 
-5. **`IsActive` filter difference**: SP1 (daily) has `IsActive` commented out on SonnellRates for MU. SP3 (reprocess) has `IsActive = 1`. This difference is preserved in the dbt model.
+5. **`IsActive` filter difference (invoice model, MU block only)**: the `fct_sonnell_invoice_totals` MU recalculation block (raw `SonnellDailySummary` × `SonnellRates`) does not filter `IsActive` in daily mode, matching SP1. This is scoped to that block only — see bug fix note below.
 
 6. **Separate macros for reprocess**: `run-operation` macros provide a CLI-friendly interface for ad-hoc reprocessing without requiring `--vars` flags. They use `api.Relation.create()` since `ref()` and `source()` are unavailable in run-operation context.
+
+7. **`IsActive = 1` on `fct_sonnell_subsystem_cost` rate join (bug fix)**: all three execution modes of `fct_sonnell_subsystem_cost` now filter `SonnellRates.IsActive = 1`. The daily-incremental and full-refresh blocks were missing this filter (only the reprocess block had it), which allowed overlapping active/inactive rate rows for the same `GroupId` + date range to fan out the `LEFT JOIN`, producing duplicate `DailySummaryId` rows with different rates. This propagated into duplicate `Regular MB/TC` invoice lines in `fct_sonnell_invoice_totals` (same period/version, different `MilesRate`/`HoursRate`) whenever `SonnellRates` had such overlaps — e.g. July 2026 MB rates. Fixed by adding `AND r.IsActive = 1` to both blocks, consistent with the reprocess block's existing behavior. This is separate from decision #5 above (the invoice model's MU block), which was intentionally left as-is.

--- a/models/sonnell/fct_sonnell_subsystem_cost.sql
+++ b/models/sonnell/fct_sonnell_subsystem_cost.sql
@@ -89,7 +89,11 @@
     The pre_hook only marks old versions when the replacement hasn't been inserted yet.
 
   RATE/AMOUNT LOGIC:
-    Rates and amounts are computed inline via LEFT JOIN with SonnellRates.
+    Rates and amounts are computed inline via LEFT JOIN with SonnellRates,
+    filtered to IsActive=1 in all three modes. Without this filter, overlapping
+    active/inactive rate rows for the same GroupId + date range fan out the join,
+    producing duplicate DailySummaryId rows with different rates — which then
+    propagate into duplicate invoice lines in fct_sonnell_invoice_totals.
     post_hooks act as a safety net to back-fill rows whose rate was missing at
     insert time but was added to SonnellRates later (replicates SP Steps 3 & 4).
 #}
@@ -115,6 +119,7 @@ WITH source_data AS (
     LEFT JOIN {{ ref('stg_sonnell_rates') }} AS r
         ON s.Subsystem = r.GroupId
         AND s.ServiceDate BETWEEN r.StartDate AND r.EndDate
+        AND r.IsActive = 1
 
 )
 
@@ -185,7 +190,9 @@ WHERE MONTH(s.ServiceDate) = {{ var('sonnell_reprocess_month') }}
 {# ── DAILY INCREMENTAL (SP1): insert any DailySummary records not yet in target.           ── #}
 {# ── pre_hook already set CurrentVersion=0 on superseded records.                          ── #}
 {# ── NOT EXISTS (ServiceDate, Version) is the primary dedup — no date restriction needed.  ── #}
-{# ── No IsActive filter on rates — matches SP1.                                           ── #}
+{# ── IsActive=1 on rates — prevents fan-out when SonnellRates has overlapping active/       ── #}
+{# ── inactive rows for the same GroupId + date range (was missing; caused duplicate         ── #}
+{# ── DailySummaryId rows with different rates, propagating into duplicate invoice lines).   ── #}
 
 SELECT
     CAST(s.Id AS INT)                                                             AS Id,
@@ -211,6 +218,7 @@ FROM {{ ref('stg_sonnell_daily_summary') }} AS s
 LEFT JOIN {{ ref('stg_sonnell_rates') }} AS r
     ON s.Subsystem = r.GroupId
     AND s.ServiceDate BETWEEN r.StartDate AND r.EndDate
+    AND r.IsActive = 1
 WHERE NOT EXISTS (
         SELECT 1 FROM {{ this }} AS t
         WHERE t.ServiceDate = s.ServiceDate

--- a/models/sonnell/schema.yml
+++ b/models/sonnell/schema.yml
@@ -125,6 +125,14 @@ models:
       Produces 3 line types per month: Regular MB/TC, Regular MU per route,
       and Offset per subsystem. Post-hooks populate InvoiceID, stats, and
       persist the 4% offset cap audit data to SonnellOffsetApplied.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - Year
+            - Month
+            - Subsystem
+            - Type
+            - Version
     columns:
       - name: Year
         description: "Calendar year of the invoice period"


### PR DESCRIPTION
Daily-incremental and full-refresh blocks in fct_sonnell_subsystem_cost joined SonnellRates by GroupId + date range only, missing the IsActive filter already present in the reprocess block. Overlapping active/ inactive rate rows for the same GroupId/date range fanned out the LEFT JOIN, producing duplicate DailySummaryId rows with different rates, which propagated into duplicate Regular MB/TC lines in fct_sonnell_invoice_totals.

Adds a dbt_utils.unique_combination_of_columns test on (Year, Month, Subsystem, Type, Version) for fct_sonnell_invoice_totals to catch recurrences.