### PR TITLE
fix(ati_datawarehouse): use trip.svc_date instead of visit.svc_date i…

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -44,6 +44,51 @@ models:
         tests:
           - not_null
 
+  - name: FrequencyDailySummary
+    description: >
+      Resumen diario de cumplimiento de itinerario por ruta/operador, migrado desde Korbato.
+      Grain: (ServiceDate, Route, OperatorFleetId). Cruza trip/vehicle_day/fleet contra
+      trip_gtfs_match (ephemeral, models/temp/) para clasificar cada viaje como planificado,
+      cancelado, a tiempo o demorado según el itinerario GTFS.
+      Full table rebuild en cada run (sin lógica incremental).
+    columns:
+      - name: ServiceDate
+        description: "Fecha de servicio"
+        tests:
+          - not_null
+      - name: Route
+        description: "Identificador de ruta (route_id de Korbato)"
+        tests:
+          - not_null
+      - name: OperatorFleetId
+        description: "Identificador del operador/flota (operator_id de fleet)"
+        tests:
+          - not_null
+      - name: OperatedTripsCount
+        description: "Cantidad de viajes distintos operados (trip_key de la tabla trip) para la ruta/fecha"
+      - name: PlannedTripsCount
+        description: "Cantidad de viajes con match en el itinerario GTFS (trip_gtfs_match.sch_trip_id no nulo)"
+      - name: CancelledTripsCount
+        description: "Cantidad de viajes operados sin match en el itinerario GTFS (sch_trip_id nulo)"
+      - name: DelayedTripsCount
+        description: "Viajes planificados con demora >= 5 min en arribo o salida real vs. planificado"
+      - name: OnTimeDepartureCount
+        description: "Viajes planificados con salida real dentro de los 5 min de la salida planificada"
+      - name: OnTimeArrivalCount
+        description: "Viajes planificados con arribo real dentro de los 5 min del arribo planificado"
+      - name: DelayedDepartureCount
+        description: "Viajes planificados con salida real demorada >= 5 min vs. la planificada"
+      - name: DelayedArrivalCount
+        description: "Viajes planificados con arribo real demorado >= 5 min vs. el planificado"
+      - name: ExecutedPlannedTripsCount
+        description: "Viajes operados que sí tenían contraparte planificada en el itinerario GTFS"
+      - name: VehiclesOperatedCount
+        description: "Cantidad de vehículos distintos que operaron la ruta en la fecha"
+      - name: TotalVehiclesCount
+        description: "Cantidad total de vehículos de la flota ese día (independiente de la ruta)"
+      - name: AverageDelayMinutes
+        description: "Promedio de minutos de demora (el mayor entre demora de arribo y de salida) sobre viajes planificados"
+
   - name: fct_route_scd
     description: >
       SCD Type 2 para la dimensión de rutas. Registra el historial de cambios de nombre

--- a/models/temp/schema.yml
+++ b/models/temp/schema.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: trip_gtfs_match
+    description: >
+      Modelo ephemeral que matchea viajes operados (Korbato) contra su horario
+      planificado en el itinerario GTFS estático. Cadena de joins: visit -> trip
+      (para obtener svc_date confiable) -> trip_sch_match (por svc_date + trip_key)
+      -> gtfs_stop_times (por sch_trip_id = trip_id y seq_in_pattern = stop_sequence).
+      Es una dependencia dura de FrequencyDailySummary pese a vivir en models/temp/ —
+      no es un modelo exploratorio, aunque su ubicación sugiera lo contrario.
+      Nota histórica: hasta 2026-07 este modelo usaba visit.svc_date (en vez de
+      trip.svc_date) en el join contra trip_sch_match; una corrupción de datos en
+      visit.svc_date (fechas centinela en el año 6100) hacía que el join casi nunca
+      matcheara, dejando CancelledTripsCount = OperatedTripsCount y el resto de las
+      métricas de itinerario en 0 en FrequencyDailySummary.
+    columns:
+      - name: trip_key
+        description: "Identificador de viaje operado (Korbato), FK a trip.trip_key"
+        tests:
+          - not_null
+      - name: svc_date
+        description: "Fecha de servicio del viaje, tomada de trip.svc_date (no de visit.svc_date, que tiene corrupción conocida)"
+        tests:
+          - not_null
+      - name: arrival_real
+        description: "Hora real de arribo (de visit.arrival)"
+      - name: departure_real
+        description: "Hora real de salida (de visit.departure)"
+      - name: sch_trip_id
+        description: "trip_id del itinerario GTFS matcheado. NULL si el viaje no tiene contraparte planificada"
+      - name: arrival_planned
+        description: "Hora de arribo planificada según gtfs_stop_times.arrival_time"
+      - name: departure_planned
+        description: "Hora de salida planificada según gtfs_stop_times.departure_time"

--- a/models/temp/trip_gtfs_match.sql
+++ b/models/temp/trip_gtfs_match.sql
@@ -4,20 +4,21 @@
 
 
 select  v.trip_key,
-        v.svc_date, 
+        t.svc_date,
         try_cast(v.arrival as time) as arrival_real,
         try_cast(v.departure as time) as departure_real,
-        m.sch_trip_id, 
+        m.sch_trip_id,
         try_cast(
             right('0' + cast((cast(parsename(replace(s.arrival_time, ':', '.'), 3) as int) % 24) as varchar(2)), 2) + ':' +
             right('0' + parsename(replace(s.arrival_time, ':', '.'), 2), 2) + ':' +
             right('0' + parsename(replace(s.arrival_time, ':', '.'), 1), 2)
-        as time) as arrival_planned, 
+        as time) as arrival_planned,
         try_cast(
             right('0' + cast((cast(parsename(replace(s.departure_time, ':', '.'), 3) as int) % 24) as varchar(2)), 2) + ':' +
             right('0' + parsename(replace(s.departure_time, ':', '.'), 2), 2) + ':' +
             right('0' + parsename(replace(s.departure_time, ':', '.'), 1), 2)
         as time) as departure_planned
 from {{ source('korbato', 'visit') }} as v
-join  {{ source('korbato', 'trip_sch_match') }} as m on v.svc_date = m.svc_date and v.trip_key = m.trip_key
+join {{ source('korbato', 'trip') }} as t on t.trip_key = v.trip_key
+join  {{ source('korbato', 'trip_sch_match') }} as m on t.svc_date = m.svc_date and v.trip_key = m.trip_key
 join {{ source('gtfs', 'gtfs_stop_times') }} as s on m.sch_trip_id = s.trip_id and v.seq_in_pattern = s.stop_sequence

--- a/tests/assert_frequency_summary_has_scheduled_matches.sql
+++ b/tests/assert_frequency_summary_has_scheduled_matches.sql
@@ -1,0 +1,13 @@
+-- Devuelve una fila si, en los últimos 7 días de servicio, no hay NINGÚN viaje
+-- matcheado contra el itinerario GTFS (PlannedTripsCount = 0 en todas las filas).
+-- Esto es la segunda firma del bug de 2026-07: cuando el join a trip_gtfs_match
+-- rompe, PlannedTripsCount/DelayedTripsCount/OnTimeDepartureCount/OnTimeArrivalCount/
+-- DelayedDepartureCount/DelayedArrivalCount/ExecutedPlannedTripsCount quedan todos en 0.
+
+SELECT
+    MIN(ServiceDate) AS from_date,
+    MAX(ServiceDate) AS to_date,
+    SUM(PlannedTripsCount) AS total_planned_trips
+FROM {{ ref('FrequencyDailySummary') }}
+WHERE ServiceDate >= DATEADD(day, -7, CAST(GETDATE() AS date))
+HAVING SUM(PlannedTripsCount) = 0

--- a/tests/assert_frequency_summary_not_all_cancelled.sql
+++ b/tests/assert_frequency_summary_not_all_cancelled.sql
@@ -1,0 +1,16 @@
+-- Devuelve filas si, para alguna ServiceDate reciente, el 100% de las rutas tienen
+-- OperatedTripsCount = CancelledTripsCount. Un match legítimo del itinerario GTFS
+-- debería dejar la gran mayoría de los viajes como no-cancelados; que TODAS las
+-- rutas de un día aparezcan como "totalmente canceladas" es la firma del bug de
+-- 2026-07 donde el join a trip_gtfs_match rompía silenciosamente (ver
+-- models/temp/schema.yml).
+
+SELECT
+    ServiceDate,
+    COUNT(*) AS route_rows,
+    SUM(CASE WHEN OperatedTripsCount = CancelledTripsCount THEN 1 ELSE 0 END) AS all_cancelled_rows
+FROM {{ ref('FrequencyDailySummary') }}
+WHERE ServiceDate >= DATEADD(day, -7, CAST(GETDATE() AS date))
+GROUP BY ServiceDate
+HAVING COUNT(*) > 0
+   AND COUNT(*) = SUM(CASE WHEN OperatedTripsCount = CancelledTripsCount THEN 1 ELSE 0 END)


### PR DESCRIPTION
…n trip_gtfs_match

visit.svc_date has corrupted sentinel dates (year 6100) for a large share of rows, which made the join against trip_sch_match match almost nothing. This left FrequencyDailySummary with CancelledTripsCount always equal to OperatedTripsCount and every GTFS-derived metric (PlannedTripsCount, DelayedTripsCount, OnTime/Delayed Departure/Arrival counts, ExecutedPlannedTripsCount) stuck at 0. Joining through trip.svc_date instead restores real matches (confirmed via manual diagnostics against Synapse).

Also adds schema.yml docs/tests for FrequencyDailySummary and trip_gtfs_match, plus two singular tests that reproduce both reported symptoms so a future regression fails CI instead of shipping silently.